### PR TITLE
feat(mappings): add filterinfos-attribution mapping

### DIFF
--- a/importer/elasticsearch-import-indices.sh
+++ b/importer/elasticsearch-import-indices.sh
@@ -35,6 +35,18 @@ do
     "settings" : { "number_of_shards" : 1, "max_result_window" : 300000, "index.requests.cache.enable": true, "index.queries.cache.enabled": true, "index.mapping.total_fields.limit": 1500 },
     "mappings": {
       "properties": {
+        "filterInfos": {
+          "properties": {
+            "attribution": {
+              "type": "nested",
+              "properties": {
+                "id": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
         "involvedPersons": {
           "type": "nested",
           "properties": {

--- a/importer/files
+++ b/importer/files
@@ -1,0 +1,1 @@
+/Users/jpereira/th-koeln/cranach/repositories/importer/docs/20211102/elasticsearch


### PR DESCRIPTION
Mit diesem PR werden Mapping-Infos für `filterInfos.attribution` hinzugefügt, damit folgender Change an der Cranach-API funktionieren kann: https://github.com/lucascranach/cranach-api/pull/52