### PR TITLE
api(assets): mount filter assets via volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,7 @@ services:
     volumes:
       - ${PATH_API}/src:/usr/src/app
       - /usr/src/app/node_modules
+      - ${PATH_API_FILTER_ASSETS}:/usr/src/app/server/assets/filters
     depends_on:
        - elasticsearch
     networks:

--- a/example-env
+++ b/example-env
@@ -4,6 +4,8 @@ PATH_ES_DATA=/path/to/esdata/
 PATH_API=/path/to/api/rep
 PATH_API_DEV=/path/to/api/rep
 
+PATH_API_FILTER_ASSETS=/path/to/filter/assets
+
 PATH_MONGO_DATA=/path/to/mongodata/
 
 


### PR DESCRIPTION
Mit diesem MR wird die Umgebung soweit angepasst, dass man die Filter-JSONs von außen via Volume einbinden kann.
So hat man die JSONs nicht in der Historie und muss nicht bei jedem neuen Export die JSONs aktualisieren (Überschreiben, commiten, pushen, deployen).
Durch die Einsatz von `nodemon`, können Filter-JSONs auch im laufenden Betrieb ausgetauscht werden, was einen fast unterbrechungsfreien Betrieb erlaubt, wenn neue Daten vorliegen.

Dieser MR hängt mit folgendem MR zusammen uns sollte mit diesem zusammen deployed bzw. getestet werden: https://github.com/lucascranach/cranach-api/pull/115