### PR TITLE
fix(renew-cert): use standalone docker-compose command

### DIFF
--- a/shscripts/renew-cert.sh
+++ b/shscripts/renew-cert.sh
@@ -2,4 +2,4 @@
 SCRIPT_DIR="$(dirname $0)"
 cd $SCRIPT_DIR/..
 
-certbot renew --quiet --deploy-hook "sudo docker compose -f docker-compose.yml -f docker-compose.prod.yml exec reverse-proxy nginx -s reload"
+certbot renew --quiet --deploy-hook "sudo docker-compose -f docker-compose.yml -f docker-compose.prod.yml exec reverse-proxy nginx -s reload"


### PR DESCRIPTION
Es wird `docker-compose` anstatt `docker compose` genutzt. Letzteres scheint es nur in aktuelleren Version von Docker (`docker-ce`) zu geben, wo Composer nun unter `compose` als Management-Kommando geführt wird.

Ich befürchte das könnte auch der Grund für das Problem mit der Zertifikaterneuerung sein :(
Hab es deshalb schon mal auf der prod-Umgebung per Hand angepasst.