### PR TITLE
fix(elasticsearch): bind volume to correct data directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     networks:
       - cranach-network
     volumes: 
-      - ${PATH_ES_DATA}:/var/lib/elasticsearch
+      - ${PATH_ES_DATA}:/usr/share/elasticsearch/data
   kibana:
     container_name: cranach-kibana
     image: docker.elastic.co/kibana/kibana:$ELASTIC_VERSION


### PR DESCRIPTION
Mit diesem PR wird der Data-Volume für die ES-Daten korrekt gebunden.
Der Data-Ordner ist mit dem aktuellsten ES-Docker-Image unter folgendem Pfad zu finden:
`/usr/share/elasticsearch/data`.

Durch das binden des Data-Volumes an einen ungünstigen Pfad, wurden die importierte Daten nicht persistent gehalten, weshalb diese nur flüchtig waren und einen Neustart des Containers nicht überstanden haben und dadurch immer erneut importiert werden mussten.