### PR TITLE
chore(proxy): adds route for cranach-ar-backend/

### DIFF
--- a/nginx-config/prod/templates/default.conf.template
+++ b/nginx-config/prod/templates/default.conf.template
@@ -28,6 +28,10 @@ server {
         proxy_pass http://172.17.0.1:8080;
     }
 
+    location /cranach-ar-backend/ {
+        proxy_pass http://172.17.0.1:8080;
+    }
+
     #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html


### PR DESCRIPTION
Die Route wird für ein Master Projekt der Medieninformatik benötigt 