### PR TITLE
feat(import): add publications mapping

### DIFF
--- a/importer/elasticsearch-import-indices.sh
+++ b/importer/elasticsearch-import-indices.sh
@@ -381,6 +381,17 @@ do
               }
             }
           }
+        },
+        "publications": {
+          "type": "nested",
+          "properties": {
+            "type": {
+              "type": "keyword"
+            },
+            "text": {
+              "type": "keyword"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Für einen sauber funktionierenden Publikations- bzw. Medientyp-Filter, muss im ES-Mapping die Struktur des `publications`-Felds beschrieben werden.

Hängt mit folgendem MR zusammen: https://github.com/lucascranach/cranach-api/pull/135