### PR TITLE
integration => master

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,16 @@ The importer is located in the directory `importer`.
 * Start the import script: `make importesinidices`
 
 ## Renew Let's Encrypt certificates
-1. Renew certificate
+1. stop API container
+```shell
+cd /var/lucascranach/cranach-docker/ && docker-compose stop reverse-proxy
+```
+2. Renew certificate
 ```shell
 sudo certbot certonly --standalone --preferred-challenges http  -d mivs02.gm.fh-koeln.de
 ```
-2. stop API container
-```shell
-cd /var/lucascranach/cranach-docker/ && docker-compose stop api
-```
 3. start API container
 ```shell
-cd /var/lucascranach/cranach-docker/ && sudo docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d api
+cd /var/lucascranach/cranach-docker/ && sudo docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d reverse-proxy
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     networks:
       - cranach-network
     volumes: 
-      - ${PATH_ES_DATA}:/var/lib/elasticsearch
+      - ${PATH_ES_DATA}:/usr/share/elasticsearch/data
   kibana:
     container_name: cranach-kibana
     image: docker.elastic.co/kibana/kibana:$ELASTIC_VERSION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     networks:
       - cranach-network
     volumes: 
-      - ${PATH_ES_DATA}:/usr/share/elasticsearch/data
+      - ${PATH_ES_DATA}:/var/lib/elasticsearch
   kibana:
     container_name: cranach-kibana
     image: docker.elastic.co/kibana/kibana:$ELASTIC_VERSION

--- a/importer/elasticsearch-import-indices.sh
+++ b/importer/elasticsearch-import-indices.sh
@@ -381,6 +381,17 @@ do
               }
             }
           }
+        },
+        "publications": {
+          "type": "nested",
+          "properties": {
+            "type": {
+              "type": "keyword"
+            },
+            "text": {
+              "type": "keyword"
+            }
+          }
         }
       }
     }

--- a/nginx-config/dev/templates/default.conf.template
+++ b/nginx-config/dev/templates/default.conf.template
@@ -1,7 +1,7 @@
 server {
     listen 80;
     listen [::]:80;
-    server_name  ${DOMAIN};
+    server_name ${DOMAIN};
 
     #access_log  /var/log/nginx/host.access.log  main;
 

--- a/nginx-config/prod/templates/default.conf.template
+++ b/nginx-config/prod/templates/default.conf.template
@@ -28,6 +28,10 @@ server {
         proxy_pass http://172.17.0.1:8080;
     }
 
+    location /cranach-ar-backend/ {
+        proxy_pass http://172.17.0.1:8080;
+    }
+
     #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html

--- a/nginx-config/prod/templates/default.conf.template
+++ b/nginx-config/prod/templates/default.conf.template
@@ -24,6 +24,10 @@ server {
         proxy_pass http://cranach-api:8080/;
     }
 
+    location /cranach-ar/ {
+        proxy_pass http://172.17.0.1:8080;
+    }
+
     #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html

--- a/shscripts/renew-cert.sh
+++ b/shscripts/renew-cert.sh
@@ -2,4 +2,4 @@
 SCRIPT_DIR="$(dirname $0)"
 cd $SCRIPT_DIR/..
 
-certbot renew --quiet --deploy-hook "sudo docker compose -f docker-compose.yml -f docker-compose.prod.yml exec reverse-proxy nginx -s reload"
+certbot renew --quiet --deploy-hook "sudo docker-compose -f docker-compose.yml -f docker-compose.prod.yml exec reverse-proxy nginx -s reload"


### PR DESCRIPTION
Da gab es leider noch Anpassungen hier im Repo die in `integration` aber noch nicht im `master` liegen.

Betrifft u.a. eine Erweiterung der `elasticsearch-import-indices.sh` um Mappings für die Publikationsdaten.

Damit es auf dem Produktivsystem funktioniert (mivs02 als Quelle), habe ich diese Änderung dort erstmal händisch vorgenommen und nochmal in ES importiert.
Das und vllt. auch die anderen Änderungen hier im PR müsste man vllt. im Kopf behalten, sollte durch einen Merge die Pipeline angestoßen werden.